### PR TITLE
Introduce pure per-repo sync planning layer

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -11,6 +11,58 @@ pub struct SyncDiff {
     pub removed_prs: Vec<PullRequest>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSyncPlan {
+    pub all_pr_numbers_to_refresh: Vec<i64>,
+    pub watermark_to_persist: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClosedPrProjection {
+    pub closed_pr_numbers: HashSet<i64>,
+    pub deleted_prs: Vec<PullRequest>,
+}
+
+pub fn build_repo_sync_plan(
+    known_pr_numbers: &[i64],
+    new_pr_numbers: &[i64],
+    max_updated_at: Option<DateTime<Utc>>,
+) -> RepoSyncPlan {
+    let mut seen = HashSet::new();
+    let all_pr_numbers_to_refresh = known_pr_numbers
+        .iter()
+        .chain(new_pr_numbers.iter())
+        .copied()
+        .filter(|number| seen.insert(*number))
+        .collect();
+
+    RepoSyncPlan {
+        all_pr_numbers_to_refresh,
+        watermark_to_persist: compute_sync_watermark(max_updated_at),
+    }
+}
+
+pub fn compute_sync_watermark(max_updated_at: Option<DateTime<Utc>>) -> Option<DateTime<Utc>> {
+    max_updated_at.map(|max_ts| max_ts - chrono::Duration::seconds(1))
+}
+
+pub fn project_closed_pull_requests(
+    existing_prs: &[PullRequest],
+    closed_pr_numbers: &[i64],
+) -> ClosedPrProjection {
+    let closed_pr_numbers: HashSet<i64> = closed_pr_numbers.iter().copied().collect();
+    let deleted_prs = existing_prs
+        .iter()
+        .filter(|pr| closed_pr_numbers.contains(&pr.number))
+        .cloned()
+        .collect();
+
+    ClosedPrProjection {
+        closed_pr_numbers,
+        deleted_prs,
+    }
+}
+
 pub fn process_pull_request_sync_results(
     prs_from_database: &[PullRequest],
     prs_from_fresh_sync: &[PullRequest],
@@ -126,9 +178,14 @@ fn collect_removed_pull_requests(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use chrono::{DateTime, TimeZone, Utc};
 
-    use super::process_pull_request_sync_results;
+    use super::{
+        build_repo_sync_plan, compute_sync_watermark, process_pull_request_sync_results,
+        project_closed_pull_requests,
+    };
     use crate::models::{ApprovalStatus, CiStatus, PullRequest};
 
     fn dt(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
@@ -338,5 +395,47 @@ mod tests {
             result.updated_prs[0].approval_status,
             ApprovalStatus::Approved
         );
+    }
+
+    #[test]
+    fn repo_sync_plan_is_empty_when_no_pr_numbers() {
+        let plan = build_repo_sync_plan(&[], &[], None);
+
+        assert!(plan.all_pr_numbers_to_refresh.is_empty());
+        assert_eq!(plan.watermark_to_persist, None);
+    }
+
+    #[test]
+    fn repo_sync_plan_deduplicates_known_and_new_numbers() {
+        let plan = build_repo_sync_plan(&[1, 2, 2], &[2, 3, 1], None);
+
+        assert_eq!(plan.all_pr_numbers_to_refresh, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn watermark_has_one_second_overlap_window() {
+        let max_updated_at = dt(2025, 1, 1, 0);
+
+        let watermark = compute_sync_watermark(Some(max_updated_at));
+
+        assert_eq!(
+            watermark,
+            Some(max_updated_at - chrono::Duration::seconds(1))
+        );
+    }
+
+    #[test]
+    fn watermark_is_none_when_no_max_updated_at() {
+        assert_eq!(compute_sync_watermark(None), None);
+    }
+
+    #[test]
+    fn projects_closed_prs_to_deleted_results() {
+        let existing_prs = vec![empty_pr("org/repo", 1), empty_pr("org/repo", 2)];
+
+        let projection = project_closed_pull_requests(&existing_prs, &[2, 3]);
+
+        assert_eq!(projection.closed_pr_numbers, HashSet::from([2, 3]));
+        assert_eq!(projection.deleted_prs, vec![empty_pr("org/repo", 2)]);
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,11 +1,12 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
-use crate::core::{process_pull_request_sync_results, SyncDiff};
+use crate::core::{
+    build_repo_sync_plan, process_pull_request_sync_results, project_closed_pull_requests, SyncDiff,
+};
 use crate::db::DatabaseRepository;
 use crate::github::GitHubClient;
 use crate::models::{PullRequest, TrackedRepository};
@@ -177,15 +178,20 @@ async fn sync_single_repo(
     .await?;
 
     // Step 3: Phase 2 — Targeted Refresh
-    // Collect ALL PR numbers to refresh: existing + newly discovered
-    let mut all_pr_numbers = known_pr_numbers;
-    all_pr_numbers.extend(&new_pr_numbers);
+    let sync_plan = build_repo_sync_plan(&known_pr_numbers, &new_pr_numbers, max_updated_at);
 
-    let (fresh_prs, all_comments, closed_pr_numbers) = if all_pr_numbers.is_empty() {
-        (Vec::new(), Vec::new(), Vec::new())
-    } else {
-        service::fetch_pull_requests_by_number(github, repo_name, &all_pr_numbers, username).await?
-    };
+    let (fresh_prs, all_comments, closed_pr_numbers) =
+        if sync_plan.all_pr_numbers_to_refresh.is_empty() {
+            (Vec::new(), Vec::new(), Vec::new())
+        } else {
+            service::fetch_pull_requests_by_number(
+                github,
+                repo_name,
+                &sync_plan.all_pr_numbers_to_refresh,
+                username,
+            )
+            .await?
+        };
 
     // Step 4: Diff & persist
     // Use process_pull_request_sync_results for open PRs (same as before)
@@ -204,8 +210,10 @@ async fn sync_single_repo(
         repository.save_pr(pr).await?;
     }
 
+    let closed_projection = project_closed_pull_requests(&existing_prs, &closed_pr_numbers);
+
     // Delete closed/merged/deleted PRs explicitly
-    for pr_number in &closed_pr_numbers {
+    for pr_number in &closed_projection.closed_pr_numbers {
         repository.delete_pr(repo_name, *pr_number).await?;
     }
 
@@ -216,31 +224,19 @@ async fn sync_single_repo(
 
     // Step 5: Update last_synced_at
     // Store the GitHub-side timestamp watermark (not local clock)
-    if let Some(max_ts) = max_updated_at {
-        // Subtract 1 second to create a small overlap window, ensuring PRs
-        // updated at exactly the watermark timestamp are re-scanned next time.
-        // These PRs will already be in our DB from this sync, so the overlap
-        // just causes them to appear in discovery (where they'll be filtered
-        // out as known PRs).
-        let watermark = max_ts - chrono::Duration::seconds(1);
+    if let Some(watermark) = sync_plan.watermark_to_persist {
         repository
             .update_tracked_repository_last_synced_at(repo_name, watermark)
             .await?;
     }
 
     // Step 6: Build result
-    let closed_set: HashSet<i64> = closed_pr_numbers.iter().copied().collect();
-    let deleted_prs: Vec<PullRequest> = existing_prs
-        .into_iter()
-        .filter(|pr| closed_set.contains(&pr.number))
-        .collect();
-
     Ok(RepoSyncResult {
         repo_name: repo_name.clone(),
         repo_index,
         new_prs,
         updated_prs,
-        deleted_prs,
+        deleted_prs: closed_projection.deleted_prs,
     })
 }
 


### PR DESCRIPTION
### Motivation
- Separate the pure planning decisions for a repository sync from the side-effecting `sync_single_repo` logic so planning can be unit-tested and reasoning about I/O is clearer.

### Description
- Add `RepoSyncPlan` and `ClosedPrProjection` in `src/core.rs` and implement `build_repo_sync_plan`, `compute_sync_watermark`, and `project_closed_pull_requests` to merge/dedupe PR numbers, compute the one-second watermark overlap, and shape closed-PR deletion payloads.
- Refactor `sync_single_repo` in `src/sync.rs` to call the pure planning functions for how many/which PRs to refresh and which to delete while preserving DB reads/writes, GitHub calls, and orchestration in the shell layer.
- Add focused unit tests in `core::tests` covering empty inputs, duplicate PR numbers deduplication, watermark edge behavior, and closed-PR projection.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check` which completed successfully.
- Ran `cargo test --lib core::tests` but the run could not complete due to unrelated compile errors in TUI test initializers referencing `PullRequest` constructors (missing `comments` field), preventing full test execution for the crate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac92d9de9c8332821ec0cc83f6f645)