### PR TITLE
Extract pure team member classification from authors-from-teams flow

### DIFF
--- a/src/cli_app.rs
+++ b/src/cli_app.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use std::io::IsTerminal;
 
 use clap::{Parser, Subcommand};
 
+use crate::core::classify_team_members;
 use crate::db::DatabaseRepository;
 use crate::github::GitHubClient;
 use crate::models::User;
@@ -137,7 +137,6 @@ async fn handle_authors_from_teams(repo: &DatabaseRepository) -> anyhow::Result<
         return Ok(());
     }
 
-    let mut seen_logins: HashSet<String> = HashSet::new();
     let mut all_members: Vec<String> = Vec::new();
 
     for team in &teams {
@@ -145,29 +144,14 @@ async fn handle_authors_from_teams(repo: &DatabaseRepository) -> anyhow::Result<
             .fetch_team_members(&team.organization.login, &team.slug)
             .await?;
         for member in members {
-            if seen_logins.insert(member.login.clone()) {
-                all_members.push(member.login);
-            }
+            all_members.push(member.login);
         }
     }
 
-    let current_login_lower = user.username.to_lowercase();
     let already_tracked: Vec<String> = repo.get_tracked_authors().await?;
-    let tracked_lower: HashSet<String> = already_tracked.iter().map(|s| s.to_lowercase()).collect();
-
-    // Split all_members into already-tracked teammates and new candidates
-    let mut tracked_teammates: Vec<String> = Vec::new();
-    let mut candidates: Vec<String> = Vec::new();
-    for login in all_members {
-        let lower = login.to_lowercase();
-        if lower == current_login_lower {
-            // skip self
-        } else if tracked_lower.contains(&lower) {
-            tracked_teammates.push(login);
-        } else {
-            candidates.push(login);
-        }
-    }
+    let classification = classify_team_members(&user.username, &already_tracked, &all_members);
+    let tracked_teammates = classification.tracked_teammates;
+    let candidates = classification.candidates;
 
     if !tracked_teammates.is_empty() {
         println!("Already tracking from your teams:");

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,6 +4,50 @@ use chrono::{DateTime, Utc};
 
 use crate::models::PullRequest;
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct TeamAuthorClassification {
+    pub tracked_teammates: Vec<String>,
+    pub candidates: Vec<String>,
+}
+
+pub fn classify_team_members(
+    current_user_login: &str,
+    existing_tracked_authors: &[String],
+    fetched_team_member_logins: &[String],
+) -> TeamAuthorClassification {
+    let current_login_lower = current_user_login.to_lowercase();
+    let tracked_lower: HashSet<String> = existing_tracked_authors
+        .iter()
+        .map(|login| login.to_lowercase())
+        .collect();
+
+    let mut seen_lower: HashSet<String> = HashSet::new();
+    let mut tracked_teammates: Vec<String> = Vec::new();
+    let mut candidates: Vec<String> = Vec::new();
+
+    for login in fetched_team_member_logins {
+        let lower = login.to_lowercase();
+        if !seen_lower.insert(lower.clone()) {
+            continue;
+        }
+
+        if lower == current_login_lower {
+            continue;
+        }
+
+        if tracked_lower.contains(&lower) {
+            tracked_teammates.push(login.clone());
+        } else {
+            candidates.push(login.clone());
+        }
+    }
+
+    TeamAuthorClassification {
+        tracked_teammates,
+        candidates,
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct SyncDiff {
     pub new_prs: Vec<PullRequest>,
@@ -128,7 +172,7 @@ fn collect_removed_pull_requests(
 mod tests {
     use chrono::{DateTime, TimeZone, Utc};
 
-    use super::process_pull_request_sync_results;
+    use super::{classify_team_members, process_pull_request_sync_results};
     use crate::models::{ApprovalStatus, CiStatus, PullRequest};
 
     fn dt(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
@@ -338,5 +382,46 @@ mod tests {
             result.updated_prs[0].approval_status,
             ApprovalStatus::Approved
         );
+    }
+
+    #[test]
+    fn classifies_team_members_with_deduping() {
+        let current_user = "alice";
+        let tracked = vec!["bob".to_string()];
+        let fetched = vec![
+            "bob".to_string(),
+            "carol".to_string(),
+            "bob".to_string(),
+            "carol".to_string(),
+        ];
+
+        let result = classify_team_members(current_user, &tracked, &fetched);
+
+        assert_eq!(result.tracked_teammates, vec!["bob".to_string()]);
+        assert_eq!(result.candidates, vec!["carol".to_string()]);
+    }
+
+    #[test]
+    fn classifies_team_members_case_insensitively() {
+        let current_user = "alice";
+        let tracked = vec!["BOB".to_string()];
+        let fetched = vec!["bOb".to_string(), "CaRoL".to_string()];
+
+        let result = classify_team_members(current_user, &tracked, &fetched);
+
+        assert_eq!(result.tracked_teammates, vec!["bOb".to_string()]);
+        assert_eq!(result.candidates, vec!["CaRoL".to_string()]);
+    }
+
+    #[test]
+    fn classifies_team_members_excluding_self() {
+        let current_user = "Alice";
+        let tracked = vec![];
+        let fetched = vec!["ALICE".to_string(), "bob".to_string()];
+
+        let result = classify_team_members(current_user, &tracked, &fetched);
+
+        assert!(result.tracked_teammates.is_empty());
+        assert_eq!(result.candidates, vec!["bob".to_string()]);
     }
 }


### PR DESCRIPTION
### Motivation
- Move team-member classification logic out of the impure `handle_authors_from_teams` flow into a pure, testable function to follow the project's functional-core/imperative-shell pattern.
- Make the classification result explicit (tracked teammates vs candidates) and preserve the existing case-insensitive matching and deduping behavior.

### Description
- Added `TeamAuthorClassification` and `classify_team_members(current_user_login, existing_tracked_authors, fetched_team_member_logins) -> TeamAuthorClassification` in `src/core.rs` implementing deduping, case-insensitive matching, and self-exclusion.
- Updated `handle_authors_from_teams` in `src/cli_app.rs` to keep only I/O responsibilities (fetch teams/members, render/prompt/save) and delegate the classification to the new pure helper.
- Added unit tests in `core` covering deduping, case-insensitive matching, and excluding the authenticated user.

### Testing
- Ran `cargo fmt` and formatting succeeded.
- Ran `cargo check` and the workspace built successfully.
- Ran `cargo test --lib core::tests`, but the test run failed to execute due to pre-existing unrelated compile errors in TUI test helpers that reference missing fields in `PullRequest` initializers, preventing test execution; the new helper and tests are self-contained and intended to run once those unrelated test errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac92db83d48332aaa06af6f89273df)