### PR TITLE
Refactor toward functional core / imperative shell architecture

### DIFF
--- a/src/cli_app.rs
+++ b/src/cli_app.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use std::io::IsTerminal;
 
 use clap::{Parser, Subcommand};
 
+use crate::core::{categorize_team_members, notification_body, prs_to_notify};
 use crate::db::DatabaseRepository;
 use crate::github::GitHubClient;
 use crate::models::User;
@@ -137,47 +137,30 @@ async fn handle_authors_from_teams(repo: &DatabaseRepository) -> anyhow::Result<
         return Ok(());
     }
 
-    let mut seen_logins: HashSet<String> = HashSet::new();
+    // Imperative shell: fetch all team members via HTTP
     let mut all_members: Vec<String> = Vec::new();
-
     for team in &teams {
         let members = github
             .fetch_team_members(&team.organization.login, &team.slug)
             .await?;
         for member in members {
-            if seen_logins.insert(member.login.clone()) {
-                all_members.push(member.login);
-            }
+            all_members.push(member.login);
         }
     }
 
-    let current_login_lower = user.username.to_lowercase();
-    let already_tracked: Vec<String> = repo.get_tracked_authors().await?;
-    let tracked_lower: HashSet<String> = already_tracked.iter().map(|s| s.to_lowercase()).collect();
+    // Pure core: categorize members
+    let already_tracked = repo.get_tracked_authors().await?;
+    let categorized = categorize_team_members(&all_members, &already_tracked, &user.username);
 
-    // Split all_members into already-tracked teammates and new candidates
-    let mut tracked_teammates: Vec<String> = Vec::new();
-    let mut candidates: Vec<String> = Vec::new();
-    for login in all_members {
-        let lower = login.to_lowercase();
-        if lower == current_login_lower {
-            // skip self
-        } else if tracked_lower.contains(&lower) {
-            tracked_teammates.push(login);
-        } else {
-            candidates.push(login);
-        }
-    }
-
-    if !tracked_teammates.is_empty() {
+    if !categorized.tracked.is_empty() {
         println!("Already tracking from your teams:");
-        for login in &tracked_teammates {
+        for login in &categorized.tracked {
             println!("  ✓ {}", login);
         }
         println!();
     }
 
-    if candidates.is_empty() {
+    if categorized.untracked.is_empty() {
         println!("All team members are already being tracked.");
         return Ok(());
     }
@@ -188,7 +171,7 @@ async fn handle_authors_from_teams(repo: &DatabaseRepository) -> anyhow::Result<
         );
     }
 
-    let selected_logins = match inquire::MultiSelect::new("Select authors to track:", candidates)
+    let selected_logins = match inquire::MultiSelect::new("Select authors to track:", categorized.untracked)
         .with_help_message("↑↓ navigate  space select  type to filter  enter confirm  esc cancel")
         .with_page_size(15)
         .prompt_skippable()
@@ -287,16 +270,9 @@ fn notify_sync_changes(summary: &SyncRunSummary, username: &str) -> anyhow::Resu
 
     #[cfg(target_os = "linux")]
     {
-        for pr in &summary.new_prs {
-            if !pr.should_notify_on_changes(username.to_string()) {
-                continue;
-            }
-
-            let body = format!(
-                "{}#{} by {} {}",
-                pr.repository, pr.number, pr.author, pr.title
-            );
-
+        // Pure core: filter which PRs should generate notifications
+        for pr in prs_to_notify(&summary.new_prs, username) {
+            let body = notification_body(pr);
             notify_rust::Notification::new()
                 .summary("PR Tracker - New PR")
                 .body(&body)
@@ -304,16 +280,8 @@ fn notify_sync_changes(summary: &SyncRunSummary, username: &str) -> anyhow::Resu
                 .show()?;
         }
 
-        for pr in &summary.updated_prs {
-            if !pr.should_notify_on_changes(username.to_string()) {
-                continue;
-            }
-
-            let body = format!(
-                "{}#{} by {} {}",
-                pr.repository, pr.number, pr.author, pr.title
-            );
-
+        for pr in prs_to_notify(&summary.updated_prs, username) {
+            let body = notification_body(pr);
             notify_rust::Notification::new()
                 .summary("PR Tracker - Updated PR")
                 .body(&body)

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 
 use crate::models::PullRequest;
+
+// ── Sync diff ───────────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
 pub struct SyncDiff {
@@ -124,11 +126,91 @@ fn collect_removed_pull_requests(
         .collect()
 }
 
+// ── Team member categorization ──────────────────────────────────────
+
+/// Result of categorizing team members into tracked and untracked groups.
+#[derive(Debug, PartialEq)]
+pub struct CategorizedMembers {
+    /// Members already being tracked.
+    pub tracked: Vec<String>,
+    /// Members not yet tracked (candidates for tracking).
+    pub untracked: Vec<String>,
+}
+
+/// Pure function: categorize a list of team member logins into tracked and untracked.
+///
+/// - Deduplicates members (case-insensitive)
+/// - Excludes `current_user` from both lists
+/// - Splits remaining into tracked vs untracked based on `already_tracked`
+/// - Both output lists are sorted alphabetically
+pub fn categorize_team_members(
+    all_member_logins: &[String],
+    already_tracked: &[String],
+    current_user: &str,
+) -> CategorizedMembers {
+    let current_lower = current_user.to_lowercase();
+    let tracked_set: HashSet<String> = already_tracked.iter().map(|s| s.to_lowercase()).collect();
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut tracked = Vec::new();
+    let mut untracked = Vec::new();
+
+    for login in all_member_logins {
+        let lower = login.to_lowercase();
+        if lower == current_lower {
+            continue; // skip self
+        }
+        if !seen.insert(lower.clone()) {
+            continue; // skip duplicate
+        }
+        if tracked_set.contains(&lower) {
+            tracked.push(login.clone());
+        } else {
+            untracked.push(login.clone());
+        }
+    }
+
+    tracked.sort();
+    untracked.sort();
+
+    CategorizedMembers { tracked, untracked }
+}
+
+// ── PR age cutoff ──────────────────────────────────────────────────
+
+/// Pure function: compute the PR age cutoff date.
+///
+/// Given a max-age in days and the current time, returns the cutoff timestamp.
+/// A value of 0 or negative means "no cutoff" (returns None).
+pub fn pr_age_cutoff(max_age_days: i64, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    if max_age_days <= 0 {
+        return None;
+    }
+    Some(now - Duration::days(max_age_days))
+}
+
+// ── Notification filtering ─────────────────────────────────────────
+
+/// Pure function: build a notification body string for a PR.
+pub fn notification_body(pr: &PullRequest) -> String {
+    format!(
+        "{}#{} by {} {}",
+        pr.repository, pr.number, pr.author, pr.title
+    )
+}
+
+/// Pure function: filter PRs that should generate notifications.
+pub fn prs_to_notify<'a>(prs: &'a [PullRequest], username: &str) -> Vec<&'a PullRequest> {
+    prs.iter()
+        .filter(|pr| pr.should_notify_on_changes(username.to_string()))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, TimeZone, Utc};
 
-    use super::process_pull_request_sync_results;
+    use super::*;
     use crate::models::{ApprovalStatus, CiStatus, PullRequest};
 
     fn dt(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
@@ -338,5 +420,120 @@ mod tests {
             result.updated_prs[0].approval_status,
             ApprovalStatus::Approved
         );
+    }
+
+    // ── categorize_team_members tests ───────────────────────────────
+
+    #[test]
+    fn categorize_excludes_current_user() {
+        let members = vec!["alice".to_string(), "bob".to_string()];
+        let tracked: Vec<String> = vec![];
+        let result = categorize_team_members(&members, &tracked, "alice");
+        assert_eq!(result.untracked, vec!["bob"]);
+        assert!(result.tracked.is_empty());
+    }
+
+    #[test]
+    fn categorize_excludes_current_user_case_insensitive() {
+        let members = vec!["Alice".to_string(), "bob".to_string()];
+        let tracked: Vec<String> = vec![];
+        let result = categorize_team_members(&members, &tracked, "alice");
+        assert_eq!(result.untracked, vec!["bob"]);
+    }
+
+    #[test]
+    fn categorize_splits_tracked_and_untracked() {
+        let members = vec![
+            "alice".to_string(),
+            "bob".to_string(),
+            "carol".to_string(),
+        ];
+        let tracked = vec!["bob".to_string()];
+        let result = categorize_team_members(&members, &tracked, "me");
+        assert_eq!(result.tracked, vec!["bob"]);
+        assert_eq!(result.untracked, vec!["alice", "carol"]);
+    }
+
+    #[test]
+    fn categorize_deduplicates_members() {
+        let members = vec![
+            "alice".to_string(),
+            "Alice".to_string(),
+            "ALICE".to_string(),
+        ];
+        let tracked: Vec<String> = vec![];
+        let result = categorize_team_members(&members, &tracked, "me");
+        assert_eq!(result.untracked.len(), 1);
+    }
+
+    #[test]
+    fn categorize_empty_members() {
+        let result = categorize_team_members(&[], &[], "me");
+        assert!(result.tracked.is_empty());
+        assert!(result.untracked.is_empty());
+    }
+
+    #[test]
+    fn categorize_sorts_output() {
+        let members = vec![
+            "zulu".to_string(),
+            "alpha".to_string(),
+            "mike".to_string(),
+        ];
+        let tracked: Vec<String> = vec![];
+        let result = categorize_team_members(&members, &tracked, "me");
+        assert_eq!(result.untracked, vec!["alpha", "mike", "zulu"]);
+    }
+
+    // ── pr_age_cutoff tests ────────────────────────────────────────
+
+    #[test]
+    fn age_cutoff_positive_days() {
+        let now = dt(2025, 6, 15, 0);
+        let result = pr_age_cutoff(7, now);
+        assert_eq!(result, Some(dt(2025, 6, 8, 0)));
+    }
+
+    #[test]
+    fn age_cutoff_zero_returns_none() {
+        let now = dt(2025, 6, 15, 0);
+        assert_eq!(pr_age_cutoff(0, now), None);
+    }
+
+    #[test]
+    fn age_cutoff_negative_returns_none() {
+        let now = dt(2025, 6, 15, 0);
+        assert_eq!(pr_age_cutoff(-5, now), None);
+    }
+
+    // ── notification filtering tests ───────────────────────────────
+
+    #[test]
+    fn notification_body_format() {
+        let pr = PullRequest {
+            title: "Fix bug".to_string(),
+            author: "alice".to_string(),
+            repository: "org/repo".to_string(),
+            number: 42,
+            ..empty_pr("org/repo", 42)
+        };
+        assert_eq!(notification_body(&pr), "org/repo#42 by alice Fix bug");
+    }
+
+    #[test]
+    fn prs_to_notify_filters_by_should_notify() {
+        let pr1 = PullRequest {
+            author: "other".to_string(),
+            ..empty_pr("org/repo", 1)
+        };
+        let pr2 = PullRequest {
+            author: "me".to_string(),
+            ..empty_pr("org/repo", 2)
+        };
+        // pr1 is by "other" so should notify "me"; pr2 is by "me" (new PR by self = no notify)
+        let prs = vec![pr1.clone(), pr2];
+        let result = prs_to_notify(&prs, "me");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].number, 1);
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -6,6 +6,8 @@ use crate::github::graphql;
 use crate::github::GitHubClient;
 use crate::models::{ApprovalStatus, CiStatus, PrComment, PullRequest};
 
+// ── Impure shell functions (HTTP I/O) ──────────────────────────────
+
 pub async fn fetch_tracked_pull_requests(
     github: &GitHubClient,
     repo_name: &str,
@@ -17,10 +19,56 @@ pub async fn fetch_tracked_pull_requests(
         .fetch_open_pull_requests_graphql(repo_name, updated_after)
         .await?;
 
+    // Pure core: filter + map
+    filter_and_map_tracked_prs(&prs, repo_name, authors_to_track, username)
+}
+
+pub async fn discover_new_pull_requests(
+    github: &GitHubClient,
+    repo_name: &str,
+    authors_to_track: &[String],
+    known_pr_numbers: &[i64],
+    updated_after: Option<DateTime<Utc>>,
+) -> anyhow::Result<(Vec<i64>, Option<DateTime<Utc>>)> {
+    let prs = github
+        .fetch_discovery_pull_requests_graphql(repo_name, updated_after)
+        .await?;
+
+    // Pure core: extract timestamps and filter
+    let max_updated_at = max_discovery_updated_at(&prs);
+    let known: HashSet<i64> = known_pr_numbers.iter().copied().collect();
+    let new_pr_numbers = filter_new_prs(&prs, authors_to_track, &known);
+
+    Ok((new_pr_numbers, max_updated_at))
+}
+
+pub async fn fetch_pull_requests_by_number(
+    github: &GitHubClient,
+    repo_name: &str,
+    pr_numbers: &[i64],
+    username: &str,
+) -> anyhow::Result<(Vec<PullRequest>, Vec<PrComment>, Vec<i64>)> {
+    let results = github
+        .fetch_pull_requests_by_number(repo_name, pr_numbers)
+        .await?;
+
+    // Pure core: classify and map
+    classify_fetched_prs(&results, repo_name, username)
+}
+
+// ── Pure core functions (no I/O) ───────────────────────────────────
+
+/// Pure: filter GraphQL PRs by author, then map to domain models.
+pub fn filter_and_map_tracked_prs(
+    prs: &[graphql::PullRequestNode],
+    repo_name: &str,
+    authors_to_track: &[String],
+    username: &str,
+) -> anyhow::Result<(Vec<PullRequest>, Vec<PrComment>)> {
     let mut pull_requests = Vec::new();
     let mut all_comments = Vec::new();
 
-    for pr in &prs {
+    for pr in prs {
         let author = pr
             .author
             .as_ref()
@@ -39,29 +87,34 @@ pub async fn fetch_tracked_pull_requests(
     Ok((pull_requests, all_comments))
 }
 
-pub async fn discover_new_pull_requests(
-    github: &GitHubClient,
+/// Pure: classify fetched PR results into open PRs, comments, and closed PR numbers.
+pub fn classify_fetched_prs(
+    results: &[(i64, Option<graphql::PullRequestNode>)],
     repo_name: &str,
-    authors_to_track: &[String],
-    known_pr_numbers: &[i64],
-    updated_after: Option<DateTime<Utc>>,
-) -> anyhow::Result<(Vec<i64>, Option<DateTime<Utc>>)> {
-    let prs = github
-        .fetch_discovery_pull_requests_graphql(repo_name, updated_after)
-        .await?;
+    username: &str,
+) -> anyhow::Result<(Vec<PullRequest>, Vec<PrComment>, Vec<i64>)> {
+    let mut open_prs = Vec::new();
+    let mut all_comments = Vec::new();
+    let mut closed_pr_numbers = Vec::new();
 
-    let max_updated_at = prs
-        .iter()
-        .filter_map(|pr| parse_github_timestamp(&pr.updated_at).ok())
-        .max();
+    for (number, maybe_node) in results {
+        match maybe_node {
+            Some(ref node) if node.state.as_deref() == Some("OPEN") => {
+                let pr_model = graphql_pr_to_model(repo_name, node, username)?;
+                all_comments.extend(pr_model.comments.clone());
+                open_prs.push(pr_model);
+            }
+            _ => {
+                closed_pr_numbers.push(*number);
+            }
+        }
+    }
 
-    let known: HashSet<i64> = known_pr_numbers.iter().copied().collect();
-    let new_pr_numbers = filter_new_prs(&prs, authors_to_track, &known);
-
-    Ok((new_pr_numbers, max_updated_at))
+    Ok((open_prs, all_comments, closed_pr_numbers))
 }
 
-fn graphql_pr_to_model(
+/// Pure: map a single GraphQL PR node to a domain PullRequest model.
+pub fn graphql_pr_to_model(
     repo_name: &str,
     pr: &graphql::PullRequestNode,
     username: &str,
@@ -114,7 +167,8 @@ fn graphql_pr_to_model(
     Ok(pr_model)
 }
 
-fn map_ci_status(pr: &graphql::PullRequestNode) -> CiStatus {
+/// Pure: map CI status from GraphQL rollup state string.
+pub fn map_ci_status(pr: &graphql::PullRequestNode) -> CiStatus {
     let rollup = pr
         .commits
         .nodes
@@ -131,7 +185,8 @@ fn map_ci_status(pr: &graphql::PullRequestNode) -> CiStatus {
     }
 }
 
-fn map_approval_status(pr: &graphql::PullRequestNode) -> ApprovalStatus {
+/// Pure: map approval status from GraphQL review states.
+pub fn map_approval_status(pr: &graphql::PullRequestNode) -> ApprovalStatus {
     let mut has_approved = false;
     for review in &pr.latest_reviews.nodes {
         match review.state.as_str() {
@@ -145,6 +200,35 @@ fn map_approval_status(pr: &graphql::PullRequestNode) -> ApprovalStatus {
     } else {
         ApprovalStatus::None
     }
+}
+
+/// Pure: extract the maximum updated_at timestamp from discovery PRs.
+pub fn max_discovery_updated_at(
+    prs: &[graphql::DiscoveryPullRequestNode],
+) -> Option<DateTime<Utc>> {
+    prs.iter()
+        .filter_map(|pr| parse_github_timestamp(&pr.updated_at).ok())
+        .max()
+}
+
+/// Pure: filter discovery PRs to find new ones by tracked authors.
+pub fn filter_new_prs(
+    prs: &[graphql::DiscoveryPullRequestNode],
+    authors_to_track: &[String],
+    known_pr_numbers: &HashSet<i64>,
+) -> Vec<i64> {
+    prs.iter()
+        .filter(|pr| {
+            let author = pr
+                .author
+                .as_ref()
+                .map(|a| a.login.as_str())
+                .unwrap_or_default();
+            authors_to_track.iter().any(|tracked| tracked == author)
+                && !known_pr_numbers.contains(&pr.number)
+        })
+        .map(|pr| pr.number)
+        .collect()
 }
 
 fn latest_review_submitted_at(pr: &graphql::PullRequestNode) -> DateTime<Utc> {
@@ -178,7 +262,6 @@ fn latest_comment_time(pr: &graphql::PullRequestNode) -> DateTime<Utc> {
 fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<PrComment> {
     let mut comments = Vec::new();
 
-    // Extract issue comments from pr.comments.nodes
     for comment in &pr.comments.nodes {
         let author = comment
             .author
@@ -186,10 +269,10 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
             .map(|a| a.login.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
-        let created_at = parse_github_timestamp(&comment.created_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
-        let updated_at = parse_github_timestamp(&comment.updated_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
+        let created_at =
+            parse_github_timestamp(&comment.created_at).unwrap_or(DateTime::UNIX_EPOCH);
+        let updated_at =
+            parse_github_timestamp(&comment.updated_at).unwrap_or(DateTime::UNIX_EPOCH);
 
         comments.push(PrComment {
             id: comment.id.clone(),
@@ -204,7 +287,6 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
         });
     }
 
-    // Extract review comments from pr.reviews.nodes
     for review in &pr.reviews.nodes {
         let author = review
             .author
@@ -212,10 +294,10 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
             .map(|a| a.login.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
-        let created_at = parse_github_timestamp(&review.created_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
-        let updated_at = parse_github_timestamp(&review.updated_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
+        let created_at =
+            parse_github_timestamp(&review.created_at).unwrap_or(DateTime::UNIX_EPOCH);
+        let updated_at =
+            parse_github_timestamp(&review.updated_at).unwrap_or(DateTime::UNIX_EPOCH);
 
         comments.push(PrComment {
             id: review.id.clone(),
@@ -233,7 +315,7 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
     comments
 }
 
-fn parse_github_timestamp(value: &str) -> anyhow::Result<DateTime<Utc>> {
+pub fn parse_github_timestamp(value: &str) -> anyhow::Result<DateTime<Utc>> {
     if value.is_empty() {
         return Ok(DateTime::UNIX_EPOCH);
     }
@@ -243,55 +325,6 @@ fn parse_github_timestamp(value: &str) -> anyhow::Result<DateTime<Utc>> {
 
 fn parse_optional_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
     value.and_then(|raw| parse_github_timestamp(raw).ok())
-}
-
-fn filter_new_prs(
-    prs: &[graphql::DiscoveryPullRequestNode],
-    authors_to_track: &[String],
-    known_pr_numbers: &HashSet<i64>,
-) -> Vec<i64> {
-    prs.iter()
-        .filter(|pr| {
-            let author = pr
-                .author
-                .as_ref()
-                .map(|a| a.login.as_str())
-                .unwrap_or_default();
-            authors_to_track.iter().any(|tracked| tracked == author)
-                && !known_pr_numbers.contains(&pr.number)
-        })
-        .map(|pr| pr.number)
-        .collect()
-}
-
-pub async fn fetch_pull_requests_by_number(
-    github: &GitHubClient,
-    repo_name: &str,
-    pr_numbers: &[i64],
-    username: &str,
-) -> anyhow::Result<(Vec<PullRequest>, Vec<PrComment>, Vec<i64>)> {
-    let results = github
-        .fetch_pull_requests_by_number(repo_name, pr_numbers)
-        .await?;
-
-    let mut open_prs = Vec::new();
-    let mut all_comments = Vec::new();
-    let mut closed_pr_numbers = Vec::new();
-
-    for (number, maybe_node) in results {
-        match maybe_node {
-            Some(ref node) if node.state.as_deref() == Some("OPEN") => {
-                let pr_model = graphql_pr_to_model(repo_name, node, username)?;
-                all_comments.extend(pr_model.comments.clone());
-                open_prs.push(pr_model);
-            }
-            _ => {
-                closed_pr_numbers.push(number);
-            }
-        }
-    }
-
-    Ok((open_prs, all_comments, closed_pr_numbers))
 }
 
 #[cfg(test)]
@@ -362,5 +395,53 @@ mod tests {
 
         let result = filter_new_prs(&prs, &authors, &known);
         assert_eq!(result, vec![1, 4]);
+    }
+
+    // ── max_discovery_updated_at tests ─────────────────────────────
+
+    #[test]
+    fn max_updated_at_returns_max_timestamp() {
+        let prs = vec![
+            discovery_pr(1, Some("alice")),
+            DiscoveryPullRequestNode {
+                number: 2,
+                updated_at: "2025-06-20T00:00:00Z".to_string(),
+                author: Some(Author {
+                    login: "bob".to_string(),
+                }),
+            },
+        ];
+        let result = max_discovery_updated_at(&prs);
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            parse_github_timestamp("2025-06-20T00:00:00Z").unwrap()
+        );
+    }
+
+    #[test]
+    fn max_updated_at_empty_returns_none() {
+        let result = max_discovery_updated_at(&[]);
+        assert!(result.is_none());
+    }
+
+    // ── parse_github_timestamp tests ───────────────────────────────
+
+    #[test]
+    fn parse_valid_timestamp() {
+        let result = parse_github_timestamp("2025-06-15T12:30:00Z");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_empty_timestamp_returns_epoch() {
+        let result = parse_github_timestamp("").unwrap();
+        assert_eq!(result, DateTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn parse_invalid_timestamp_returns_error() {
+        let result = parse_github_timestamp("not-a-date");
+        assert!(result.is_err());
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
-use crate::core::{process_pull_request_sync_results, SyncDiff};
+use crate::core::{pr_age_cutoff, process_pull_request_sync_results, SyncDiff};
 use crate::db::DatabaseRepository;
 use crate::github::GitHubClient;
 use crate::models::{PullRequest, TrackedRepository};
@@ -14,17 +14,13 @@ use crate::service;
 const DEFAULT_MAX_PR_AGE_DAYS: i64 = 7;
 const MAX_CONCURRENT_REPOS: usize = 5;
 
-fn pr_age_cutoff() -> Option<DateTime<Utc>> {
+/// Read the PR age cutoff from environment, delegating to the pure `core::pr_age_cutoff`.
+fn read_pr_age_cutoff() -> Option<DateTime<Utc>> {
     let days: i64 = std::env::var("PR_TRACKER_MAX_PR_AGE_DAYS")
         .ok()
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(DEFAULT_MAX_PR_AGE_DAYS);
-
-    if days <= 0 {
-        return None; // 0 or negative means no cutoff (fetch all)
-    }
-
-    Some(Utc::now() - chrono::Duration::days(days))
+    pr_age_cutoff(days, Utc::now())
 }
 
 /// Compute the discovery cutoff for a repository.
@@ -161,7 +157,7 @@ async fn sync_single_repo(
     let repo_name = &tracked_repo.repository;
 
     // Step 1: Compute cutoff
-    let discovery_cutoff = compute_discovery_cutoff(tracked_repo.last_synced_at, pr_age_cutoff());
+    let discovery_cutoff = compute_discovery_cutoff(tracked_repo.last_synced_at, read_pr_age_cutoff());
 
     // Step 2: Phase 1 — Discovery
     let existing_prs = repository.get_prs_by_repository(repo_name).await?;

--- a/src/tui/authors/events.rs
+++ b/src/tui/authors/events.rs
@@ -5,38 +5,100 @@ use crate::tui::authors::State;
 use crate::tui::navigation::{AuthorsPane, Screen};
 use crate::tui::pr_list::events::EventResult;
 
-/// Handle a key event for the Authors screen.
-pub async fn handle_event(
-    key_code: KeyCode,
-    state: &mut State,
-    repo: &DatabaseRepository,
-) -> anyhow::Result<EventResult> {
+/// A pure description of what side effect to perform on the Authors screen.
+#[derive(Debug, PartialEq)]
+pub enum AuthorAction {
+    /// No side effect needed.
+    None,
+    /// Switch back to the PR list screen.
+    SwitchToPrList,
+    /// Track an author: move from untracked to tracked and persist.
+    TrackAuthor {
+        /// Index in the *original* untracked list (before filtering).
+        original_index: usize,
+    },
+    /// Untrack an author: move from tracked to untracked and persist.
+    UntrackAuthor {
+        /// Index in the *original* tracked list (before filtering).
+        original_index: usize,
+    },
+}
+
+/// Pure function: given the current state and a key press, decide what action to take.
+///
+/// This function performs NO I/O. It only reads state and returns an action description.
+pub fn resolve_event(key_code: KeyCode, state: &State) -> AuthorAction {
     if state.loading {
-        // When loading, only allow Esc and 'q' to exit
         match key_code {
-            KeyCode::Esc | KeyCode::Char('q') => {
-                return Ok(EventResult::SwitchScreen(Screen::PrList));
-            }
-            _ => return Ok(EventResult::Continue),
+            KeyCode::Esc | KeyCode::Char('q') => return AuthorAction::SwitchToPrList,
+            _ => return AuthorAction::None,
         }
     }
 
-    // Not loading - handle all keys
+    match key_code {
+        KeyCode::Esc => {
+            if state.search_query.is_empty() {
+                AuthorAction::SwitchToPrList
+            } else {
+                AuthorAction::None // will be handled by apply_navigation
+            }
+        }
+
+        KeyCode::Char('q') => {
+            if state.search_query.is_empty() {
+                AuthorAction::SwitchToPrList
+            } else {
+                AuthorAction::None // 'q' appended to search by apply_navigation
+            }
+        }
+
+        KeyCode::Enter | KeyCode::Char(' ') => match state.focus {
+            AuthorsPane::Untracked => {
+                let filtered = state.filtered_list(&state.untracked);
+                let cursor = state.untracked_cursor;
+                match filtered.get(cursor) {
+                    Some(&(orig_idx, _)) => AuthorAction::TrackAuthor {
+                        original_index: orig_idx,
+                    },
+                    None => AuthorAction::None,
+                }
+            }
+            AuthorsPane::Tracked => {
+                let filtered = state.filtered_list(&state.tracked);
+                let cursor = state.tracked_cursor;
+                match filtered.get(cursor) {
+                    Some(&(orig_idx, _)) => AuthorAction::UntrackAuthor {
+                        original_index: orig_idx,
+                    },
+                    None => AuthorAction::None,
+                }
+            }
+        },
+
+        // All other keys (navigation, search) are handled purely by apply_navigation
+        _ => AuthorAction::None,
+    }
+}
+
+/// Pure function: apply navigation and search-related key events to state.
+///
+/// Handles cursor movement, tab switching, search input — no I/O.
+pub fn apply_navigation(key_code: KeyCode, state: &mut State) {
+    if state.loading {
+        return;
+    }
+
     match key_code {
         KeyCode::Esc => {
             if !state.search_query.is_empty() {
                 state.search_query.clear();
                 state.tracked_cursor = 0;
                 state.untracked_cursor = 0;
-            } else {
-                return Ok(EventResult::SwitchScreen(Screen::PrList));
             }
         }
 
         KeyCode::Char('q') => {
-            if state.search_query.is_empty() {
-                return Ok(EventResult::SwitchScreen(Screen::PrList));
-            } else {
+            if !state.search_query.is_empty() {
                 state.search_query.push('q');
                 state.tracked_cursor = 0;
                 state.untracked_cursor = 0;
@@ -62,12 +124,8 @@ pub async fn handle_event(
 
         KeyCode::Down | KeyCode::Char('j') => {
             let filtered_len = match state.focus {
-                AuthorsPane::Tracked => {
-                    state.filtered_list(&state.tracked).len()
-                }
-                AuthorsPane::Untracked => {
-                    state.filtered_list(&state.untracked).len()
-                }
+                AuthorsPane::Tracked => state.filtered_list(&state.tracked).len(),
+                AuthorsPane::Untracked => state.filtered_list(&state.untracked).len(),
             };
             let cursor = match state.focus {
                 AuthorsPane::Tracked => &mut state.tracked_cursor,
@@ -75,35 +133,6 @@ pub async fn handle_event(
             };
             if filtered_len > 0 && *cursor + 1 < filtered_len {
                 *cursor += 1;
-            }
-        }
-
-        KeyCode::Enter | KeyCode::Char(' ') => {
-            match state.focus {
-                AuthorsPane::Untracked => {
-                    let filtered = state.filtered_list(&state.untracked);
-                    let cursor = state.untracked_cursor;
-                    if let Some(&(orig_idx, _)) = filtered.get(cursor) {
-                        let login = state.untracked.remove(orig_idx);
-                        repo.save_tracked_author(&login).await?;
-                        state.tracked.push(login);
-                        state.tracked.sort();
-                        state.search_query.clear();
-                        state.clamp_cursors();
-                    }
-                }
-                AuthorsPane::Tracked => {
-                    let filtered = state.filtered_list(&state.tracked);
-                    let cursor = state.tracked_cursor;
-                    if let Some(&(orig_idx, _)) = filtered.get(cursor) {
-                        let login = state.tracked.remove(orig_idx);
-                        repo.delete_tracked_author(&login).await?;
-                        state.untracked.push(login);
-                        state.untracked.sort();
-                        state.search_query.clear();
-                        state.clamp_cursors();
-                    }
-                }
             }
         }
 
@@ -121,6 +150,281 @@ pub async fn handle_event(
 
         _ => {}
     }
+}
 
-    Ok(EventResult::Continue)
+/// Pure function: apply a track action to the state.
+///
+/// Returns the login string for persistence by the imperative shell.
+pub fn apply_track(state: &mut State, original_index: usize) -> Option<String> {
+    if original_index >= state.untracked.len() {
+        return None;
+    }
+    let login = state.untracked.remove(original_index);
+    state.tracked.push(login.clone());
+    state.tracked.sort();
+    state.search_query.clear();
+    state.clamp_cursors();
+    Some(login)
+}
+
+/// Pure function: apply an untrack action to the state.
+///
+/// Returns the login string for persistence by the imperative shell.
+pub fn apply_untrack(state: &mut State, original_index: usize) -> Option<String> {
+    if original_index >= state.tracked.len() {
+        return None;
+    }
+    let login = state.tracked.remove(original_index);
+    state.untracked.push(login.clone());
+    state.untracked.sort();
+    state.search_query.clear();
+    state.clamp_cursors();
+    Some(login)
+}
+
+/// Imperative shell: execute an author action, performing all necessary I/O.
+pub async fn execute_action(
+    action: AuthorAction,
+    state: &mut State,
+    repo: &DatabaseRepository,
+) -> anyhow::Result<EventResult> {
+    match action {
+        AuthorAction::None => Ok(EventResult::Continue),
+        AuthorAction::SwitchToPrList => Ok(EventResult::SwitchScreen(Screen::PrList)),
+
+        AuthorAction::TrackAuthor { original_index } => {
+            if let Some(login) = apply_track(state, original_index) {
+                repo.save_tracked_author(&login).await?;
+            }
+            Ok(EventResult::Continue)
+        }
+
+        AuthorAction::UntrackAuthor { original_index } => {
+            if let Some(login) = apply_untrack(state, original_index) {
+                repo.delete_tracked_author(&login).await?;
+            }
+            Ok(EventResult::Continue)
+        }
+    }
+}
+
+/// Top-level handler: resolves the event purely, then executes the resulting action.
+pub async fn handle_event(
+    key_code: KeyCode,
+    state: &mut State,
+    repo: &DatabaseRepository,
+) -> anyhow::Result<EventResult> {
+    // Pure: decide what action to take (before navigation modifies state)
+    let action = resolve_event(key_code, state);
+
+    // Pure: apply navigation state changes
+    apply_navigation(key_code, state);
+
+    // Impure: execute the action
+    execute_action(action, state, repo).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::navigation::AuthorsPane;
+
+    fn state_with_authors() -> State {
+        let mut state = State::new();
+        state.loading = false;
+        state.tracked = vec!["alice".to_string(), "bob".to_string()];
+        state.untracked = vec!["carol".to_string(), "dave".to_string()];
+        state
+    }
+
+    // ── resolve_event tests ─────────────────────────────────────────
+
+    #[test]
+    fn resolve_quit_when_loading() {
+        let mut state = State::new();
+        state.loading = true;
+        assert_eq!(
+            resolve_event(KeyCode::Char('q'), &state),
+            AuthorAction::SwitchToPrList
+        );
+        assert_eq!(
+            resolve_event(KeyCode::Esc, &state),
+            AuthorAction::SwitchToPrList
+        );
+    }
+
+    #[test]
+    fn resolve_other_key_when_loading() {
+        let mut state = State::new();
+        state.loading = true;
+        assert_eq!(resolve_event(KeyCode::Enter, &state), AuthorAction::None);
+    }
+
+    #[test]
+    fn resolve_esc_with_empty_search_exits() {
+        let state = state_with_authors();
+        assert_eq!(
+            resolve_event(KeyCode::Esc, &state),
+            AuthorAction::SwitchToPrList
+        );
+    }
+
+    #[test]
+    fn resolve_esc_with_search_returns_none() {
+        let mut state = state_with_authors();
+        state.search_query = "test".to_string();
+        assert_eq!(resolve_event(KeyCode::Esc, &state), AuthorAction::None);
+    }
+
+    #[test]
+    fn resolve_q_with_empty_search_exits() {
+        let state = state_with_authors();
+        assert_eq!(
+            resolve_event(KeyCode::Char('q'), &state),
+            AuthorAction::SwitchToPrList
+        );
+    }
+
+    #[test]
+    fn resolve_q_with_search_returns_none() {
+        let mut state = state_with_authors();
+        state.search_query = "test".to_string();
+        assert_eq!(
+            resolve_event(KeyCode::Char('q'), &state),
+            AuthorAction::None
+        );
+    }
+
+    #[test]
+    fn resolve_enter_on_untracked_returns_track() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Untracked;
+        state.untracked_cursor = 0;
+        let action = resolve_event(KeyCode::Enter, &state);
+        assert_eq!(
+            action,
+            AuthorAction::TrackAuthor {
+                original_index: 0
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enter_on_tracked_returns_untrack() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Tracked;
+        state.tracked_cursor = 1;
+        let action = resolve_event(KeyCode::Enter, &state);
+        assert_eq!(
+            action,
+            AuthorAction::UntrackAuthor {
+                original_index: 1
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_enter_on_empty_untracked_returns_none() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Untracked;
+        state.untracked = vec![];
+        assert_eq!(resolve_event(KeyCode::Enter, &state), AuthorAction::None);
+    }
+
+    // ── apply_navigation tests ──────────────────────────────────────
+
+    #[test]
+    fn navigation_tab_toggles_focus() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Tracked;
+        apply_navigation(KeyCode::Tab, &mut state);
+        assert_eq!(state.focus, AuthorsPane::Untracked);
+        apply_navigation(KeyCode::Tab, &mut state);
+        assert_eq!(state.focus, AuthorsPane::Tracked);
+    }
+
+    #[test]
+    fn navigation_up_decrements_cursor() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Tracked;
+        state.tracked_cursor = 1;
+        apply_navigation(KeyCode::Up, &mut state);
+        assert_eq!(state.tracked_cursor, 0);
+    }
+
+    #[test]
+    fn navigation_down_increments_cursor() {
+        let mut state = state_with_authors();
+        state.focus = AuthorsPane::Untracked;
+        state.untracked_cursor = 0;
+        apply_navigation(KeyCode::Down, &mut state);
+        assert_eq!(state.untracked_cursor, 1);
+    }
+
+    #[test]
+    fn navigation_char_appends_to_search() {
+        let mut state = state_with_authors();
+        apply_navigation(KeyCode::Char('x'), &mut state);
+        assert_eq!(state.search_query, "x");
+    }
+
+    #[test]
+    fn navigation_backspace_removes_from_search() {
+        let mut state = state_with_authors();
+        state.search_query = "abc".to_string();
+        apply_navigation(KeyCode::Backspace, &mut state);
+        assert_eq!(state.search_query, "ab");
+    }
+
+    #[test]
+    fn navigation_noop_when_loading() {
+        let mut state = State::new();
+        state.loading = true;
+        apply_navigation(KeyCode::Char('a'), &mut state);
+        assert_eq!(state.search_query, "");
+    }
+
+    // ── apply_track / apply_untrack tests ───────────────────────────
+
+    #[test]
+    fn apply_track_moves_to_tracked() {
+        let mut state = state_with_authors();
+        let login = apply_track(&mut state, 0);
+        assert_eq!(login, Some("carol".to_string()));
+        assert!(state.tracked.contains(&"carol".to_string()));
+        assert!(!state.untracked.contains(&"carol".to_string()));
+    }
+
+    #[test]
+    fn apply_track_out_of_bounds_returns_none() {
+        let mut state = state_with_authors();
+        assert_eq!(apply_track(&mut state, 99), None);
+    }
+
+    #[test]
+    fn apply_untrack_moves_to_untracked() {
+        let mut state = state_with_authors();
+        let login = apply_untrack(&mut state, 0);
+        assert_eq!(login, Some("alice".to_string()));
+        assert!(!state.tracked.contains(&"alice".to_string()));
+        assert!(state.untracked.contains(&"alice".to_string()));
+    }
+
+    #[test]
+    fn apply_untrack_out_of_bounds_returns_none() {
+        let mut state = state_with_authors();
+        assert_eq!(apply_untrack(&mut state, 99), None);
+    }
+
+    #[test]
+    fn apply_track_clears_search_and_sorts() {
+        let mut state = state_with_authors();
+        state.search_query = "carol".to_string();
+        apply_track(&mut state, 0);
+        assert_eq!(state.search_query, "");
+        let sorted: Vec<String> = state.tracked.clone();
+        let mut expected = sorted.clone();
+        expected.sort();
+        assert_eq!(sorted, expected);
+    }
 }

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -31,7 +31,7 @@ impl ViewMode {
 }
 
 /// Which pane is focused on the Authors screen.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AuthorsPane {
     Tracked,
     Untracked,

--- a/src/tui/pr_list/events.rs
+++ b/src/tui/pr_list/events.rs
@@ -1,5 +1,7 @@
 use crossterm::event::KeyCode;
 
+use chrono::{DateTime, Utc};
+
 use crate::db::DatabaseRepository;
 use crate::models::PullRequest;
 use crate::tui::navigation::Screen;
@@ -7,7 +9,6 @@ use crate::tui::pr_list::State;
 use crate::tui::state::SharedState;
 use crate::tui::tasks::{spawn_full_sync, BackgroundJob, BackgroundMessage};
 
-use chrono::Utc;
 use tokio::sync::mpsc;
 
 /// Result of handling a key event.
@@ -20,7 +21,189 @@ pub enum EventResult {
     SwitchScreen(Screen),
 }
 
-/// Handle a key event for the PR List screen.
+/// A pure description of what side effect to perform.
+/// Returned by the pure `resolve_event` function; executed by the impure shell.
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    /// No side effect needed.
+    None,
+    /// Quit the TUI.
+    Quit,
+    /// Open a URL in the default browser.
+    OpenUrl(String),
+    /// Acknowledge a PR: update the PR at `pr_index` in `shared.prs` with the given timestamp and persist.
+    AcknowledgePr {
+        pr_index: usize,
+        now: DateTime<Utc>,
+    },
+    /// Toggle between Active and Acknowledged views.
+    ToggleView,
+    /// Start a full sync job.
+    StartSync,
+    /// Switch to the Authors screen.
+    SwitchToAuthors,
+}
+
+/// Pure function: given the current state and a key press, decide what action to take.
+///
+/// This function only reads state and returns a description of the desired effect.
+/// It does NOT perform any I/O, database writes, or state mutation.
+pub fn resolve_event(
+    key_code: KeyCode,
+    state: &State,
+    shared: &SharedState,
+    has_active_job: bool,
+) -> Action {
+    let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
+
+    match key_code {
+        KeyCode::Char('q') => Action::Quit,
+
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+            // Navigation is handled purely by apply_action on the state
+            Action::None
+        }
+
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            let mut cursor = state.cursor;
+            if !filtered_indices.is_empty() && cursor >= filtered_indices.len() {
+                cursor = filtered_indices.len() - 1;
+            }
+            match filtered_indices.get(cursor) {
+                Some(&pr_index) => Action::OpenUrl(shared.prs[pr_index].url()),
+                None => Action::None,
+            }
+        }
+
+        KeyCode::Char('a') => {
+            let mut cursor = state.cursor;
+            if !filtered_indices.is_empty() && cursor >= filtered_indices.len() {
+                cursor = filtered_indices.len() - 1;
+            }
+            match filtered_indices.get(cursor) {
+                Some(&pr_index) => Action::AcknowledgePr {
+                    pr_index,
+                    now: Utc::now(),
+                },
+                None => Action::None,
+            }
+        }
+
+        KeyCode::Char('v') => Action::ToggleView,
+
+        KeyCode::Char('s') => {
+            if has_active_job {
+                Action::None
+            } else {
+                Action::StartSync
+            }
+        }
+
+        KeyCode::Char('t') => {
+            if has_active_job {
+                Action::None
+            } else {
+                Action::SwitchToAuthors
+            }
+        }
+
+        _ => Action::None,
+    }
+}
+
+/// Pure function: apply navigation-related key events to state.
+///
+/// Handles cursor movement and view toggling without any I/O.
+pub fn apply_navigation(
+    key_code: KeyCode,
+    state: &mut State,
+    shared: &SharedState,
+) {
+    let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
+    state.ensure_cursor_in_range(filtered_indices.len());
+
+    match key_code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            if state.cursor > 0 {
+                state.cursor -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if state.cursor + 1 < filtered_indices.len() {
+                state.cursor += 1;
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Pure function: apply an acknowledge action to the shared state.
+///
+/// Returns the updated PR for persistence by the imperative shell.
+pub fn apply_acknowledge(
+    shared: &mut SharedState,
+    state: &mut State,
+    pr_index: usize,
+    now: DateTime<Utc>,
+) -> Option<PullRequest> {
+    if pr_index >= shared.prs.len() {
+        return None;
+    }
+    let mut pr = shared.prs[pr_index].clone();
+    pr.last_acknowledged_at = Some(now);
+    shared.prs[pr_index] = pr.clone();
+
+    let updated_filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
+    state.ensure_cursor_in_range(updated_filtered_indices.len());
+
+    Some(pr)
+}
+
+/// Imperative shell: execute an action, performing all necessary I/O.
+///
+/// This is the only function in this module that performs side effects.
+pub async fn execute_action(
+    action: Action,
+    state: &mut State,
+    shared: &mut SharedState,
+    repo: &DatabaseRepository,
+    tx: &mpsc::UnboundedSender<BackgroundMessage>,
+) -> anyhow::Result<EventResult> {
+    match action {
+        Action::None => Ok(EventResult::Continue),
+        Action::Quit => Ok(EventResult::Quit),
+
+        Action::OpenUrl(url) => {
+            let _ = open::that(url);
+            Ok(EventResult::Continue)
+        }
+
+        Action::AcknowledgePr { pr_index, now } => {
+            if let Some(pr) = apply_acknowledge(shared, state, pr_index, now) {
+                repo.save_pr(&pr).await?;
+            }
+            Ok(EventResult::Continue)
+        }
+
+        Action::ToggleView => {
+            state.toggle_view();
+            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
+            state.ensure_cursor_in_range(filtered_indices.len());
+            Ok(EventResult::Continue)
+        }
+
+        Action::StartSync => {
+            spawn_full_sync(repo.clone(), tx.clone());
+            Ok(EventResult::Continue)
+        }
+
+        Action::SwitchToAuthors => Ok(EventResult::SwitchScreen(Screen::AuthorsFromTeams)),
+    }
+}
+
+/// Top-level handler: resolves the event purely, then executes the resulting action.
+///
+/// This is the entry point called by the TUI event loop.
 pub async fn handle_event(
     key_code: KeyCode,
     state: &mut State,
@@ -29,78 +212,14 @@ pub async fn handle_event(
     repo: &DatabaseRepository,
     tx: &mpsc::UnboundedSender<BackgroundMessage>,
 ) -> anyhow::Result<EventResult> {
-    match key_code {
-        KeyCode::Char('q') => Ok(EventResult::Quit),
+    // Pure: apply navigation state changes
+    apply_navigation(key_code, state, shared);
 
-        KeyCode::Up | KeyCode::Char('k') => {
-            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-            state.ensure_cursor_in_range(filtered_indices.len());
-            if state.cursor > 0 {
-                state.cursor -= 1;
-            }
-            Ok(EventResult::Continue)
-        }
+    // Pure: decide what action to take
+    let action = resolve_event(key_code, state, shared, active_job.is_some());
 
-        KeyCode::Down | KeyCode::Char('j') => {
-            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-            state.ensure_cursor_in_range(filtered_indices.len());
-            if state.cursor + 1 < filtered_indices.len() {
-                state.cursor += 1;
-            }
-            Ok(EventResult::Continue)
-        }
-
-        KeyCode::Enter | KeyCode::Char(' ') => {
-            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-            state.ensure_cursor_in_range(filtered_indices.len());
-            if let Some(pr_index) = state.selected_index(&filtered_indices) {
-                let pr = &shared.prs[pr_index];
-                let _ = open::that(pr.url());
-            }
-            Ok(EventResult::Continue)
-        }
-
-        KeyCode::Char('a') => {
-            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-            state.ensure_cursor_in_range(filtered_indices.len());
-            if let Some(pr_index) = state.selected_index(&filtered_indices) {
-                let mut pr = shared.prs[pr_index].clone();
-                pr.last_acknowledged_at = Some(Utc::now());
-                repo.save_pr(&pr).await?;
-                shared.prs[pr_index] = pr;
-
-                let updated_filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-                state.ensure_cursor_in_range(updated_filtered_indices.len());
-            }
-            Ok(EventResult::Continue)
-        }
-
-        KeyCode::Char('v') => {
-            state.toggle_view();
-            let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
-            state.ensure_cursor_in_range(filtered_indices.len());
-            Ok(EventResult::Continue)
-        }
-
-        KeyCode::Char('s') => {
-            if active_job.is_some() {
-                return Ok(EventResult::Continue);
-            }
-
-            spawn_full_sync(repo.clone(), tx.clone());
-            Ok(EventResult::Continue)
-        }
-
-        KeyCode::Char('t') => {
-            if active_job.is_none() {
-                Ok(EventResult::SwitchScreen(Screen::AuthorsFromTeams))
-            } else {
-                Ok(EventResult::Continue)
-            }
-        }
-
-        _ => Ok(EventResult::Continue),
-    }
+    // Impure: execute the action
+    execute_action(action, state, shared, repo, tx).await
 }
 
 /// Helper function to get the currently selected PR.
@@ -113,4 +232,195 @@ pub fn get_selected_pr<'a>(
     state
         .selected_index(&filtered_indices)
         .and_then(|index| shared.prs.get(index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ApprovalStatus, CiStatus, PullRequest};
+    use chrono::{DateTime, TimeZone};
+
+    fn test_pr(number: i64) -> PullRequest {
+        PullRequest {
+            number,
+            title: format!("PR #{number}"),
+            repository: "owner/repo".to_string(),
+            author: "alice".to_string(),
+            head_sha: "abc123".to_string(),
+            draft: false,
+            created_at: DateTime::UNIX_EPOCH,
+            updated_at: DateTime::UNIX_EPOCH,
+            ci_status: CiStatus::Pending,
+            last_comment_at: DateTime::UNIX_EPOCH,
+            last_commit_at: DateTime::UNIX_EPOCH,
+            last_ci_status_update_at: DateTime::UNIX_EPOCH,
+            approval_status: ApprovalStatus::None,
+            last_review_status_update_at: DateTime::UNIX_EPOCH,
+            last_acknowledged_at: None,
+            requested_reviewers: Vec::new(),
+            user_has_reviewed: false,
+            comments: Vec::new(),
+        }
+    }
+
+    // ── resolve_event tests ──────────────────────────────────────────
+
+    #[test]
+    fn resolve_quit() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('q'), &state, &shared, false), Action::Quit);
+    }
+
+    #[test]
+    fn resolve_navigation_returns_none() {
+        let state = State::new();
+        let shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Up, &state, &shared, false), Action::None);
+        assert_eq!(resolve_event(KeyCode::Down, &state, &shared, false), Action::None);
+        assert_eq!(resolve_event(KeyCode::Char('k'), &state, &shared, false), Action::None);
+        assert_eq!(resolve_event(KeyCode::Char('j'), &state, &shared, false), Action::None);
+    }
+
+    #[test]
+    fn resolve_open_url_returns_url_for_selected_pr() {
+        let state = State::new();
+        let shared = SharedState::new(vec![test_pr(42)], "bob".to_string());
+        let action = resolve_event(KeyCode::Enter, &state, &shared, false);
+        assert_eq!(action, Action::OpenUrl("https://github.com/owner/repo/pull/42".to_string()));
+    }
+
+    #[test]
+    fn resolve_open_url_on_empty_list() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Enter, &state, &shared, false), Action::None);
+    }
+
+    #[test]
+    fn resolve_acknowledge_returns_pr_index() {
+        let state = State::new();
+        let shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+        let action = resolve_event(KeyCode::Char('a'), &state, &shared, false);
+        match action {
+            Action::AcknowledgePr { pr_index, .. } => assert_eq!(pr_index, 0),
+            other => panic!("expected AcknowledgePr, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_acknowledge_on_empty_list() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('a'), &state, &shared, false), Action::None);
+    }
+
+    #[test]
+    fn resolve_toggle_view() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('v'), &state, &shared, false), Action::ToggleView);
+    }
+
+    #[test]
+    fn resolve_sync_when_no_active_job() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('s'), &state, &shared, false), Action::StartSync);
+    }
+
+    #[test]
+    fn resolve_sync_when_job_active() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('s'), &state, &shared, true), Action::None);
+    }
+
+    #[test]
+    fn resolve_switch_to_authors_when_no_job() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('t'), &state, &shared, false), Action::SwitchToAuthors);
+    }
+
+    #[test]
+    fn resolve_switch_to_authors_blocked_by_active_job() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('t'), &state, &shared, true), Action::None);
+    }
+
+    #[test]
+    fn resolve_unknown_key_returns_none() {
+        let state = State::new();
+        let shared = SharedState::new(vec![], "bob".to_string());
+        assert_eq!(resolve_event(KeyCode::Char('x'), &state, &shared, false), Action::None);
+    }
+
+    // ── apply_navigation tests ──────────────────────────────────────
+
+    #[test]
+    fn navigation_up_decrements_cursor() {
+        let mut state = State::new();
+        state.cursor = 1;
+        let shared = SharedState::new(vec![test_pr(1), test_pr(2)], "bob".to_string());
+
+        apply_navigation(KeyCode::Up, &mut state, &shared);
+        assert_eq!(state.cursor, 0);
+    }
+
+    #[test]
+    fn navigation_up_at_zero_stays() {
+        let mut state = State::new();
+        let shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+
+        apply_navigation(KeyCode::Up, &mut state, &shared);
+        assert_eq!(state.cursor, 0);
+    }
+
+    #[test]
+    fn navigation_down_increments_cursor() {
+        let mut state = State::new();
+        let shared = SharedState::new(vec![test_pr(1), test_pr(2)], "bob".to_string());
+
+        apply_navigation(KeyCode::Down, &mut state, &shared);
+        assert_eq!(state.cursor, 1);
+    }
+
+    #[test]
+    fn navigation_down_at_end_stays() {
+        let mut state = State::new();
+        state.cursor = 0;
+        let shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+
+        apply_navigation(KeyCode::Down, &mut state, &shared);
+        assert_eq!(state.cursor, 0);
+    }
+
+    // ── apply_acknowledge tests ─────────────────────────────────────
+
+    #[test]
+    fn acknowledge_updates_pr_in_shared_state() {
+        let mut shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+        let mut state = State::new();
+        let now = Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap();
+
+        let result = apply_acknowledge(&mut shared, &mut state, 0, now);
+
+        assert!(result.is_some());
+        let pr = result.unwrap();
+        assert_eq!(pr.last_acknowledged_at, Some(now));
+        assert_eq!(shared.prs[0].last_acknowledged_at, Some(now));
+    }
+
+    #[test]
+    fn acknowledge_out_of_bounds_returns_none() {
+        let mut shared = SharedState::new(vec![test_pr(1)], "bob".to_string());
+        let mut state = State::new();
+        let now = Utc::now();
+
+        let result = apply_acknowledge(&mut shared, &mut state, 99, now);
+
+        assert!(result.is_none());
+    }
 }

--- a/src/tui/pr_list/state.rs
+++ b/src/tui/pr_list/state.rs
@@ -120,6 +120,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -109,6 +109,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/tasks.rs
+++ b/src/tui/tasks.rs
@@ -1,5 +1,6 @@
 use tokio::sync::mpsc;
 
+use crate::core::categorize_team_members;
 use crate::db::DatabaseRepository;
 use crate::github::GitHubClient;
 use crate::sync::{sync_all_tracked_with_progress, SyncRunSummary};
@@ -66,36 +67,26 @@ async fn run_teams_fetch(repo: DatabaseRepository) -> anyhow::Result<TeamsPayloa
     let github = GitHubClient::new(user.access_token.clone())?;
 
     let tracked_authors = repo.get_tracked_authors().await?;
-    let tracked_set: std::collections::HashSet<String> =
-        tracked_authors.iter().map(|s| s.to_lowercase()).collect();
-    let current_login_lower = user.username.to_lowercase();
 
+    // Imperative shell: fetch all team members via HTTP
     let teams = github.fetch_user_teams().await?;
-
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut all_members: Vec<String> = Vec::new();
     for team in &teams {
         let members = github
             .fetch_team_members(&team.organization.login, &team.slug)
             .await?;
         for member in members {
-            let lower = member.login.to_lowercase();
-            if lower != current_login_lower && seen.insert(lower.clone()) {
-                all_members.push(member.login);
-            }
+            all_members.push(member.login);
         }
     }
 
-    let mut untracked: Vec<String> = all_members
-        .into_iter()
-        .filter(|login| !tracked_set.contains(&login.to_lowercase()))
-        .collect();
-    untracked.sort();
+    // Pure core: categorize members
+    let categorized = categorize_team_members(&all_members, &tracked_authors, &user.username);
 
-    let mut tracked = tracked_authors;
-    tracked.sort();
-
-    Ok(TeamsPayload { tracked, untracked })
+    Ok(TeamsPayload {
+        tracked: categorized.tracked,
+        untracked: categorized.untracked,
+    })
 }
 
 /// Get a human-readable label for a background job.

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -92,6 +92,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Extract pure business logic from side-effecting code across the codebase:

- TUI event handling: introduce Action/AuthorAction enums with pure resolve_event() and apply_navigation() functions, separating "what to do" decisions from I/O execution (execute_action)
- Team member categorization: extract categorize_team_members() into core, eliminating duplicate logic between cli_app.rs and tui/tasks.rs
- Service layer: make mapping functions (graphql_pr_to_model, map_ci_status, map_approval_status, etc.) public; extract filter_and_map_tracked_prs() and classify_fetched_prs() as pure functions
- PR age cutoff: extract pure pr_age_cutoff(days, now) into core, with thin read_pr_age_cutoff() shell in sync.rs reading env vars
- Notification filtering: extract prs_to_notify() and notification_body() into core for testability

Test count: 139 → 193 (54 new tests covering all extracted pure functions)

https://claude.ai/code/session_014cn5PST5tHGatRDRHQMtbd