### PR TITLE
Follow-up: fix formatting/lint issues and restore test builders

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -389,7 +389,11 @@ impl DatabaseRepository {
         .bind(&comment.body)
         .bind(comment.created_at.timestamp())
         .bind(comment.updated_at.timestamp())
-        .bind(if comment.is_review_comment { 1i64 } else { 0i64 })
+        .bind(if comment.is_review_comment {
+            1i64
+        } else {
+            0i64
+        })
         .bind(&comment.review_state)
         .execute(&self.pool)
         .await?;
@@ -424,66 +428,12 @@ impl DatabaseRepository {
         repository: &str,
         pr_number: i64,
     ) -> anyhow::Result<()> {
-        sqlx::query(
-            "DELETE FROM pr_comments WHERE repository = ?1 AND pr_number = ?2",
-        )
-        .bind(repository)
-        .bind(pr_number)
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("DELETE FROM pr_comments WHERE repository = ?1 AND pr_number = ?2")
+            .bind(repository)
+            .bind(pr_number)
+            .execute(&self.pool)
+            .await?;
         Ok(())
-    }
-}
-
-#[derive(Debug, FromRow)]
-struct PullRequestRow {
-    number: i64,
-    title: String,
-    repository: String,
-    author: String,
-    head_sha: String,
-    draft: bool,
-    created_at_unix: i64,
-    updated_at_unix: i64,
-    ci_status: i64,
-    last_comment_unix: i64,
-    last_commit_unix: i64,
-    last_ci_status_update_unix: i64,
-    last_acknowledged_unix: Option<i64>,
-    requested_reviewers: String,
-    approval_status: i64,
-    last_review_status_update_unix: i64,
-    user_has_reviewed: bool,
-}
-
-impl PullRequestRow {
-    fn into_model(self) -> anyhow::Result<PullRequest> {
-        let requested_reviewers: Vec<String> = serde_json::from_str(&self.requested_reviewers)
-            .map_err(|err| anyhow::anyhow!("unmarshal requested_reviewers: {err}"))?;
-
-        Ok(PullRequest {
-            number: self.number,
-            title: self.title,
-            repository: self.repository,
-            author: self.author,
-            head_sha: self.head_sha,
-            draft: self.draft,
-            created_at: unix_to_datetime(self.created_at_unix)?,
-            updated_at: unix_to_datetime(self.updated_at_unix)?,
-            ci_status: CiStatus::from_i64(self.ci_status),
-            last_comment_at: unix_to_datetime(self.last_comment_unix)?,
-            last_commit_at: unix_to_datetime(self.last_commit_unix)?,
-            last_ci_status_update_at: unix_to_datetime(self.last_ci_status_update_unix)?,
-            approval_status: ApprovalStatus::from_i64(self.approval_status),
-            last_review_status_update_at: unix_to_datetime(self.last_review_status_update_unix)?,
-            last_acknowledged_at: self
-                .last_acknowledged_unix
-                .map(unix_to_datetime)
-                .transpose()?,
-            requested_reviewers,
-            user_has_reviewed: self.user_has_reviewed,
-            comments: vec![],
-        })
     }
 }
 
@@ -530,7 +480,7 @@ struct CommentJson {
     body: String,
     created_at_unix: i64,
     updated_at_unix: i64,
-    is_review_comment: i64,  // stored as 0/1 in JSON
+    is_review_comment: i64, // stored as 0/1 in JSON
     review_state: Option<String>,
 }
 
@@ -610,7 +560,7 @@ impl PullRequestWithCommentsRow {
                 .transpose()?,
             requested_reviewers,
             user_has_reviewed: self.user_has_reviewed,
-            comments,  // NEW: populated from JSON
+            comments, // NEW: populated from JSON
         })
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -186,10 +186,10 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
             .map(|a| a.login.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
-        let created_at = parse_github_timestamp(&comment.created_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
-        let updated_at = parse_github_timestamp(&comment.updated_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
+        let created_at =
+            parse_github_timestamp(&comment.created_at).unwrap_or(DateTime::UNIX_EPOCH);
+        let updated_at =
+            parse_github_timestamp(&comment.updated_at).unwrap_or(DateTime::UNIX_EPOCH);
 
         comments.push(PrComment {
             id: comment.id.clone(),
@@ -212,10 +212,8 @@ fn map_comments_from_pr(repo_name: &str, pr: &graphql::PullRequestNode) -> Vec<P
             .map(|a| a.login.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
-        let created_at = parse_github_timestamp(&review.created_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
-        let updated_at = parse_github_timestamp(&review.updated_at)
-            .unwrap_or(DateTime::UNIX_EPOCH);
+        let created_at = parse_github_timestamp(&review.created_at).unwrap_or(DateTime::UNIX_EPOCH);
+        let updated_at = parse_github_timestamp(&review.updated_at).unwrap_or(DateTime::UNIX_EPOCH);
 
         comments.push(PrComment {
             id: review.id.clone(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -60,10 +60,7 @@ pub async fn run() -> anyhow::Result<()> {
 }
 
 /// Set up terminal and run the TUI inner loop.
-async fn run_tui(
-    app_state: AppState,
-    repo: &DatabaseRepository,
-) -> anyhow::Result<()> {
+async fn run_tui(app_state: AppState, repo: &DatabaseRepository) -> anyhow::Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;

--- a/src/tui/authors/events.rs
+++ b/src/tui/authors/events.rs
@@ -62,12 +62,8 @@ pub async fn handle_event(
 
         KeyCode::Down | KeyCode::Char('j') => {
             let filtered_len = match state.focus {
-                AuthorsPane::Tracked => {
-                    state.filtered_list(&state.tracked).len()
-                }
-                AuthorsPane::Untracked => {
-                    state.filtered_list(&state.untracked).len()
-                }
+                AuthorsPane::Tracked => state.filtered_list(&state.tracked).len(),
+                AuthorsPane::Untracked => state.filtered_list(&state.untracked).len(),
             };
             let cursor = match state.focus {
                 AuthorsPane::Tracked => &mut state.tracked_cursor,
@@ -78,34 +74,32 @@ pub async fn handle_event(
             }
         }
 
-        KeyCode::Enter | KeyCode::Char(' ') => {
-            match state.focus {
-                AuthorsPane::Untracked => {
-                    let filtered = state.filtered_list(&state.untracked);
-                    let cursor = state.untracked_cursor;
-                    if let Some(&(orig_idx, _)) = filtered.get(cursor) {
-                        let login = state.untracked.remove(orig_idx);
-                        repo.save_tracked_author(&login).await?;
-                        state.tracked.push(login);
-                        state.tracked.sort();
-                        state.search_query.clear();
-                        state.clamp_cursors();
-                    }
-                }
-                AuthorsPane::Tracked => {
-                    let filtered = state.filtered_list(&state.tracked);
-                    let cursor = state.tracked_cursor;
-                    if let Some(&(orig_idx, _)) = filtered.get(cursor) {
-                        let login = state.tracked.remove(orig_idx);
-                        repo.delete_tracked_author(&login).await?;
-                        state.untracked.push(login);
-                        state.untracked.sort();
-                        state.search_query.clear();
-                        state.clamp_cursors();
-                    }
+        KeyCode::Enter | KeyCode::Char(' ') => match state.focus {
+            AuthorsPane::Untracked => {
+                let filtered = state.filtered_list(&state.untracked);
+                let cursor = state.untracked_cursor;
+                if let Some(&(orig_idx, _)) = filtered.get(cursor) {
+                    let login = state.untracked.remove(orig_idx);
+                    repo.save_tracked_author(&login).await?;
+                    state.tracked.push(login);
+                    state.tracked.sort();
+                    state.search_query.clear();
+                    state.clamp_cursors();
                 }
             }
-        }
+            AuthorsPane::Tracked => {
+                let filtered = state.filtered_list(&state.tracked);
+                let cursor = state.tracked_cursor;
+                if let Some(&(orig_idx, _)) = filtered.get(cursor) {
+                    let login = state.tracked.remove(orig_idx);
+                    repo.delete_tracked_author(&login).await?;
+                    state.untracked.push(login);
+                    state.untracked.sort();
+                    state.search_query.clear();
+                    state.clamp_cursors();
+                }
+            }
+        },
 
         KeyCode::Backspace => {
             state.search_query.pop();

--- a/src/tui/pr_list/events.rs
+++ b/src/tui/pr_list/events.rs
@@ -69,7 +69,8 @@ pub async fn handle_event(
                 repo.save_pr(&pr).await?;
                 shared.prs[pr_index] = pr;
 
-                let updated_filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
+                let updated_filtered_indices =
+                    state.filtered_indices(&shared.prs, &shared.username);
                 state.ensure_cursor_in_range(updated_filtered_indices.len());
             }
             Ok(EventResult::Continue)
@@ -105,10 +106,7 @@ pub async fn handle_event(
 
 /// Helper function to get the currently selected PR.
 /// Used when acknowledging or opening PRs.
-pub fn get_selected_pr<'a>(
-    state: &State,
-    shared: &'a SharedState,
-) -> Option<&'a PullRequest> {
+pub fn get_selected_pr<'a>(state: &State, shared: &'a SharedState) -> Option<&'a PullRequest> {
     let filtered_indices = state.filtered_indices(&shared.prs, &shared.username);
     state
         .selected_index(&filtered_indices)

--- a/src/tui/pr_list/state.rs
+++ b/src/tui/pr_list/state.rs
@@ -120,6 +120,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -109,6 +109,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/tasks.rs
+++ b/src/tui/tasks.rs
@@ -117,6 +117,9 @@ mod tests {
 
     #[test]
     fn background_job_label_teams_fetch() {
-        assert_eq!(background_job_label(BackgroundJob::TeamsFetch), "fetching teams");
+        assert_eq!(
+            background_job_label(BackgroundJob::TeamsFetch),
+            "fetching teams"
+        );
     }
 }

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -92,6 +92,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 


### PR DESCRIPTION
### Motivation
- The project had formatting, lint and compiler warnings (including a `dead_code` failure) that prevented a clean `cargo clippy -- -D warnings` run and caused test builds to fail.
- Remove the unused DB conversion path and align test fixtures with the current `PullRequest` model so unit tests and linters pass.
- Normalize formatting to satisfy `rustfmt` and small style issues surfaced by CI tools.

### Description
- Removed the unused `PullRequestRow` struct and its unused `into_model` method from `src/db.rs` and consolidated DB → model conversion to the existing `PullRequestWithCommentsRow`/`PrCommentRow` paths.
- Deserialized and populated `comments` from the joined JSON in `PullRequestWithCommentsRow::into_model` so PRs returned from DB include comments.
- Restored test helper builders in TUI test modules by adding the missing `comments: Vec::new()` field to `test_pr()` in `src/tui/state.rs`, `src/tui/pr_list/state.rs`, and `src/tui/widgets.rs` so tests compile against the current model.
- Applied `rustfmt`-driven formatting and small restructuring changes across `src/service.rs`, `src/tui/*` and other touched files to satisfy formatting/lint rules.

### Testing
- Ran `cargo fmt --check` which passed after formatting changes.
- Ran `cargo clippy -- -D warnings` which finished with no warnings/errors.
- Ran `cargo check` which completed successfully.
- Ran `cargo test` and all unit tests passed (`139 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acb140de108332b822782cfe09ee80)