### PR TITLE
Show comment count in PR update notifications

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -146,11 +146,28 @@ impl PullRequest {
         })
     }
 
+    pub fn new_comment_count_since_ack(&self) -> usize {
+        match self.last_acknowledged_at {
+            None => self.comments.len(),
+            Some(last_ack) => self
+                .comments
+                .iter()
+                .filter(|c| c.created_at > last_ack)
+                .count(),
+        }
+    }
+
     pub fn updates_since_last_ack(&self) -> String {
         if let Some(last_ack) = self.last_acknowledged_at {
             let mut updates = String::from("  ");
             if self.last_comment_at > last_ack {
-                updates.push_str("New Comment | ");
+                let count = self
+                    .comments
+                    .iter()
+                    .filter(|c| c.created_at > last_ack)
+                    .count();
+                let noun = if count == 1 { "Comment" } else { "Comments" };
+                updates.push_str(&format!("{count} New {noun} | "));
             }
             if self.last_commit_at > last_ack {
                 updates.push_str("New Commits | ");

--- a/src/tui/pr_list/state.rs
+++ b/src/tui/pr_list/state.rs
@@ -120,6 +120,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: vec![],
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -109,6 +109,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: vec![],
         }
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -92,6 +92,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary
Enhanced the pull request update notifications to display the count of new comments since last acknowledgment, with proper pluralization of the "Comment/Comments" noun.

## Key Changes
- Added `new_comment_count_since_ack()` method to `PullRequest` to calculate the number of comments created after the last acknowledgment
- Updated `updates_since_last_ack()` to display the actual count of new comments (e.g., "3 New Comments" instead of generic "New Comment")
- Implemented proper pluralization logic: uses "Comment" for singular and "Comments" for plural
- Updated test fixtures in three test modules to include the `comments` field in mock `PullRequest` objects

## Implementation Details
- The new `new_comment_count_since_ack()` method handles the case where `last_acknowledged_at` is `None` by returning the total comment count
- When `last_acknowledged_at` is set, it filters comments by creation timestamp to count only those created after acknowledgment
- The notification string now uses `format!()` to dynamically include the count and appropriate noun form

https://claude.ai/code/session_01NHJ5e8QbsgcmettUDAGuhx