### PR TITLE
Follow-up: show comment counts in TUI updates since acknowledgement

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -94,6 +94,17 @@ pub struct PullRequest {
 }
 
 impl PullRequest {
+    pub fn comment_count_since_last_ack(&self) -> usize {
+        match self.last_acknowledged_at {
+            Some(last_ack) => self
+                .comments
+                .iter()
+                .filter(|comment| comment.created_at > last_ack)
+                .count(),
+            None => self.comments.len(),
+        }
+    }
+
     pub fn is_acknowledged(&self) -> bool {
         let Some(last_ack) = self.last_acknowledged_at else {
             return false;
@@ -150,7 +161,10 @@ impl PullRequest {
         if let Some(last_ack) = self.last_acknowledged_at {
             let mut updates = String::from("  ");
             if self.last_comment_at > last_ack {
-                updates.push_str("New Comment | ");
+                updates.push_str(&format!(
+                    "New Comments ({}) | ",
+                    self.comment_count_since_last_ack()
+                ));
             }
             if self.last_commit_at > last_ack {
                 updates.push_str("New Commits | ");
@@ -378,5 +392,68 @@ mod tests {
 
         assert!(pr.user_is_involved("octocat"));
         assert!(pr.user_is_involved("reviewer"));
+    }
+
+    #[test]
+    fn comment_count_since_last_ack_counts_only_new_comments() {
+        let mut pr =
+            build_pull_request(&[TestPrEvent::Comment, TestPrEvent::Ack, TestPrEvent::Comment]);
+        pr.comments = vec![
+            PrComment {
+                id: "1".to_string(),
+                repository: "owner/repo".to_string(),
+                pr_number: 42,
+                author: "octocat".to_string(),
+                body: "before ack".to_string(),
+                created_at: timestamp(2),
+                updated_at: timestamp(2),
+                is_review_comment: false,
+                review_state: None,
+            },
+            PrComment {
+                id: "2".to_string(),
+                repository: "owner/repo".to_string(),
+                pr_number: 42,
+                author: "octocat".to_string(),
+                body: "after ack".to_string(),
+                created_at: timestamp(4),
+                updated_at: timestamp(4),
+                is_review_comment: false,
+                review_state: None,
+            },
+        ];
+
+        assert_eq!(pr.comment_count_since_last_ack(), 1);
+    }
+
+    #[test]
+    fn updates_since_last_ack_includes_new_comment_count() {
+        let mut pr = build_pull_request(&[TestPrEvent::Ack, TestPrEvent::Comment]);
+        pr.comments = vec![
+            PrComment {
+                id: "1".to_string(),
+                repository: "owner/repo".to_string(),
+                pr_number: 42,
+                author: "octocat".to_string(),
+                body: "after ack".to_string(),
+                created_at: timestamp(3),
+                updated_at: timestamp(3),
+                is_review_comment: false,
+                review_state: None,
+            },
+            PrComment {
+                id: "2".to_string(),
+                repository: "owner/repo".to_string(),
+                pr_number: 42,
+                author: "octocat".to_string(),
+                body: "after ack 2".to_string(),
+                created_at: timestamp(4),
+                updated_at: timestamp(4),
+                is_review_comment: false,
+                review_state: None,
+            },
+        ];
+
+        assert!(pr.updates_since_last_ack().contains("New Comments (2)"));
     }
 }

--- a/src/tui/pr_list/state.rs
+++ b/src/tui/pr_list/state.rs
@@ -120,6 +120,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -109,6 +109,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -92,6 +92,7 @@ mod tests {
             last_acknowledged_at: None,
             requested_reviewers: Vec::new(),
             user_has_reviewed: false,
+            comments: Vec::new(),
         }
     }
 


### PR DESCRIPTION
### Motivation
- Make the TUI updates line more informative by showing how many comments appeared since a PR was last acknowledged so users can see comment volume at a glance.
- Keep counting logic in the pure model layer so it remains testable and separated from I/O or rendering.

### Description
- Added `PullRequest::comment_count_since_last_ack()` to count comments created after `last_acknowledged_at` (or return total comments when never acknowledged) in `src/models.rs`.
- Updated `PullRequest::updates_since_last_ack()` to display comment updates as `New Comments (<count>)` instead of a generic `New Comment` in `src/models.rs`.
- Added focused unit tests that validate counting only post-ack comments and that the updates string includes the comment count in `src/models.rs` tests.
- Updated TUI test helpers to populate the new `comments` field (`src/tui/widgets.rs`, `src/tui/state.rs`, `src/tui/pr_list/state.rs`) so test fixtures match the updated `PullRequest` shape.

### Testing
- Ran `cargo fmt --all` and `cargo fmt --check`, both completed successfully.
- Ran the new focused tests with `cargo test comment_count_since_last_ack_counts_only_new_comments` and `cargo test updates_since_last_ack_includes_new_comment_count`, and both tests passed.
- Ran `cargo check`, which completed successfully.
- Ran `cargo clippy -- -D warnings`, which failed due to pre-existing `dead_code` warnings in `src/db.rs` unrelated to this change.
- `just agent-full-verify` was not available in this environment, so equivalent checks were executed directly with Cargo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ace2f5ac0c833286662539790a4068)